### PR TITLE
Refactor: Make labels screen-reader friendly

### DIFF
--- a/src/built-in-types/TextType/TextWrite.svelte
+++ b/src/built-in-types/TextType/TextWrite.svelte
@@ -11,6 +11,6 @@
 
 <label>
     {input.label}
+    <input type="text" name={input.name} placeholder={input.placeholder} bind:value/>
 </label>
-<input type="text" name={input.name} placeholder={input.placeholder} bind:value/>
 <ErrorMessage/>


### PR DESCRIPTION
## Description

Screen readers work better when labels are tied to an input. Since we're creating inputs programmatically, there should be no reason to not support this.

There's basically 2 ways to achieve this:

1. Assign an id to each input & reference that id in the corresponding label with a `for` attribute
2. Nest inputs inside their labels

Option 1 doesn't make sense using svelte (we don't need IDs), and also option 2 is easier to implement, so that's what I'm proposing.